### PR TITLE
Remove input POST encoding loop

### DIFF
--- a/ajax_locations.php
+++ b/ajax_locations.php
@@ -1,11 +1,6 @@
 <?php
 
-$url = 'http://bidfta.bidqt.com/BidFTA/services/invoices/queryExecutor/queries/FTALocations?size=50';
-
-
-//Encode POST values
-foreach($fields as $key=>$value) { $fields_string .= $key.'='.$value.'&'; }
-rtrim($fields_string, '&');
+$url = 'http://bidfta.bidqt.com/BidFTA/services/invoices/queryExecutor/queries/FTALocations?size=100';
 
 //CURL request
 $ch = curl_init();


### PR DESCRIPTION
It caused a warning that read directly into JSON.parse(data) and
appeared to be unnecessary. Also increased size of request now that ~72 locations are open